### PR TITLE
Add llama3.2 model to copilot settings

### DIFF
--- a/addons/copilot/CopilotUI.tscn
+++ b/addons/copilot/CopilotUI.tscn
@@ -115,7 +115,7 @@ layout_mode = 2
 [node name="Model" type="OptionButton" parent="VBoxParent/ModelSetting"]
 layout_mode = 2
 size_flags_horizontal = 10
-item_count = 3
+item_count = 4
 selected = 1
 fit_to_longest_item = false
 popup/item_0/text = "text-davinci-003"
@@ -124,6 +124,8 @@ popup/item_1/text = "gpt-3.5-turbo"
 popup/item_1/id = 1
 popup/item_2/text = "gpt-4"
 popup/item_2/id = 2
+popup/item_3/text = "llama3.2"
+popup/item_3/id = 3
 
 [node name="ShortcutSetting" type="HBoxContainer" parent="VBoxParent"]
 custom_minimum_size = Vector2(2.08165e-12, 2.08165e-12)

--- a/addons/copilot/Llama.gd
+++ b/addons/copilot/Llama.gd
@@ -41,7 +41,8 @@ func _get_models():
 		"llama-7b",
 		"llama-13b",
 		"llama-30b",
-		"llama-65b"
+		"llama-65b",
+		"llama3.2"
 	]
 
 func _set_model(model_name):


### PR DESCRIPTION
Add `llama3.2` model option to copilot settings.

* Modify `addons/copilot/Llama.gd` to include `llama3.2` in the `_get_models` function.
* Update `addons/copilot/CopilotUI.tscn` to add `llama3.2` to the `Model` OptionButton.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ticklecatisback/godot-copilot?shareId=591924f0-6c5b-4cc6-9d75-1ea7bf00fdc8).